### PR TITLE
Fixes findByICE(0) and findByHex when hex is in lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -1036,7 +1036,7 @@ function findByKey(key, val) {
   var found
 
   list.forEach(function (item) {
-    if (item[key] && item[key] === val) {
+    if (item[key] !== undefined && item[key] === val) {
       found = item
     }
   })
@@ -1051,6 +1051,6 @@ module.exports = {
     return findByKey('aci', aci)
   },
   getByHEX(hex) {
-    return findByKey('hex', hex)
+    return findByKey('hex', hex.toUpperCase())
   }
 }


### PR DESCRIPTION
Fixed a couple of bugs:

1. `findByICE(0)` returned undefined instead of the first element in the array.
2. `findByHex` didn't work if hex value was expressed in lowercase.
